### PR TITLE
Add explicit link to RDF 1.1 Primer

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,6 +408,7 @@ Group.</p>
             <li>Use case and requirement documents;</li>
             <li>Test suite and implementation report for the specification;</li>
             <li>Primer or Best Practice documents to support web developers when designing applications.</li>
+            <li>In particular, an updated version of the <a href="https://www.w3.org/TR/rdf11-primer/">RDF 1.1 Primer</a>;
             <li>Guidelines about how and which <a href="https://www.w3.org/2020/Process-20200915/#allow-new-features">new features</a> may be further added to the recommendations.</li>
           </ul>
 

--- a/index.html
+++ b/index.html
@@ -407,8 +407,8 @@ Group.</p>
           <ul>
             <li>Use case and requirement documents;</li>
             <li>Test suite and implementation report for the specification;</li>
-            <li>Primer or Best Practice documents to support web developers when designing applications.</li>
-            <li>In particular, an updated version of the <a href="https://www.w3.org/TR/rdf11-primer/">RDF 1.1 Primer</a>;
+            <li>Primer or Best Practice documents to support web developers when designing applications, 
+                including an update of the <a href="https://www.w3.org/TR/rdf11-primer/">RDF 1.1 Primer</a></li>
             <li>Guidelines about how and which <a href="https://www.w3.org/2020/Process-20200915/#allow-new-features">new features</a> may be further added to the recommendations.</li>
           </ul>
 


### PR DESCRIPTION
address #14


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star-wg-charter/pull/17.html" title="Last updated on Mar 7, 2022, 4:42 PM UTC (172856d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star-wg-charter/17/089c975...172856d.html" title="Last updated on Mar 7, 2022, 4:42 PM UTC (172856d)">Diff</a>