### PR TITLE
set timeline to 24 months, as resolved for #25

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
               End date
             </th>
             <td>
-              <i class="todo">[dd monthname yyyy]</i>
+              <i class="todo">[start date + 24 months]</i>
             </td>
           </tr>
           <tr>
@@ -198,7 +198,7 @@
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2011/rdf-wg/wiki/Main_Page">RDF WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2014/REC-rdf11-concepts-20140225/">RDF 1.1 Concepts and Abstract Syntax</a>, eds. Richard Cyganiak, David Wood, Markus Lanthaler, W3C Recommendation.</p>
               <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#concepts">Section 2 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 12 months</i></p>
             </dd>
 
             <dt id="n-quads" class="spec">RDF <span class="issue">1.2</span> N-Quads</dt>
@@ -208,7 +208,7 @@
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2011/rdf-wg/wiki/Main_Page">RDF WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2014/REC-n-quads-20140225/">RDF 1.1 N-Quads</a>, ed. Gavin Carothers, W3C Recommendation.</p>
               <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#n-quads-star">Section 3.5 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 12 months</i></p>
             </dd>
 
             <dt id="n-triples" class="spec">RDF <span class="issue">1.2</span> N-Triples</dt>
@@ -218,7 +218,7 @@
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2011/rdf-wg/wiki/Main_Page">RDF WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2014/REC-n-triples-20140225/">RDF 1.1 N-Triples</a>, eds. Gavin Carothers, Andy Seaborne, W3C Recommendation.</p>
               <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#n-triples-star">Section 3.4 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 12 months</i></p>
             </dd>
 
             <dt id="rdf11-mt" class="spec">RDF <span class="issue">1.2</span> Semantics</dt>
@@ -228,7 +228,7 @@
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2011/rdf-wg/wiki/Main_Page">RDF WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2014/REC-rdf11-mt-20140225/">RDF 1.1 Semantics</a>, eds. Patrick J. Hayes, Peter F. Patel-Schneider, W3C Recommendation.</p>
               <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#rdf-star-semantics">Section 6 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 18 months</i></p>
             </dd>
 
             <dt id="trig" class="spec">RDF <span class="issue">1.2</span> TriG</dt>
@@ -238,7 +238,7 @@
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2011/rdf-wg/wiki/Main_Page">RDF WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2014/REC-trig-20140225/">RDF 1.1 TriG</a>, eds. Gavin Carothers, Andy Seaborne, W3C Recommendation.</p>
               <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#trig-star">Section 3.3 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 12 months</i></p>
             </dd>
 
             <dt id="turtle" class="spec">RDF <span class="issue">1.2</span> Turtle</dt>
@@ -248,7 +248,7 @@
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2011/rdf-wg/wiki/Main_Page">RDF WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2014/REC-turtle-20140225/">RDF 1.1 Turtle</a>, eds. Eric Prud'hommeaux, Gavin Carothers, W3C Recommendation.</p>
               <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#turtle-star">Section 3.2 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 12 months</i></p>
             </dd>
 
             <dt id="rdf-syntax-grammar" class="spec">RDF <span class="issue">1.2</span> XML Syntax</dt>
@@ -257,7 +257,7 @@
 
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2011/rdf-wg/wiki/Main_Page">RDF WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2014/REC-rdf-syntax-grammar-20140225/">RDF 1.1 XML Syntax</a>, eds. Fabien Gandon, Guus Schreiber, W3C Recommendation.</p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 18 months</i></p>
               <p>This Working Group will update this normative references and address the editorial errata in this document. It may revise its content in order to integrate RDF-star features, provided enough interest and manpower.</p>
             </dd>
 
@@ -268,7 +268,7 @@
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2011/rdf-wg/wiki/Main_Page">RDF WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2014/REC-rdf-schema-20140225/">RDF Schema 1.1</a>, eds. Dan Brickley, R.V. Guha, W3C Recommendation.</p>
               <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#rdf-star-vocabulary">Section 7 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 18 months</i></p>
             </dd>
             </dl>
           </section>
@@ -286,7 +286,7 @@
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2013/REC-sparql11-overview-20130321/">SPARQL 1.1 Overview</a>, ed. The W3C SPARQL Working
 Group.</p>
               <p class="draft-status"><b>Reference:</b> <i>none</i></p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 24 months</i></p>
               </dd>
 
             <dt id="sparql11-query" class="spec">SPARQL <span class="issue">1.2</span> Query Language</dt>
@@ -296,7 +296,7 @@ Group.</p>
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2009/sparql/wiki/Main_Page">SPARQL (1.1) WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2013/REC-sparql11-query-20130321/">SPARQL 1.1 Query Language</a>, eds. Steve Harris, Andy Seaborne, W3C Recommendation.</p>
               <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#sparql-star">Section 4 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 18 months</i></p>
             </dd>
 
             <dt id="sparql11-update" class="spec">SPARQL <span class="issue">1.2</span> Update</dt>
@@ -306,7 +306,7 @@ Group.</p>
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2009/sparql/wiki/Main_Page">SPARQL (1.1) WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2013/REC-sparql11-update-20130321/">SPARQL 1.1 Update</a>, eds. Paula Gearon, Alexandre Passant, Axel Polleres, W3C Recommendation.</p>
               <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#sparql-star-update">Section 5 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 18 months</i></p>
             </dd>
 
             <dt id="sparql11-results-json" class="spec">SPARQL <span class="issue">1.2</span> Query Results JSON Format</dt>
@@ -316,7 +316,7 @@ Group.</p>
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2009/sparql/wiki/Main_Page">SPARQL (1.1) WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2013/REC-sparql11-results-json-20130321/">SPARQL 1.1 Query Results JSON Format</a>, ed. Andy Seaborne, W3C Recommendation.</p>
               <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#sparql-star-query-results-json-format">Section 4.7.1 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 18 months</i></p>
             </dd>
 
             <dt id="sparql11-results-xml" class="spec">SPARQL <span class="issue">1.2</span> Query Results XML Format</dt>
@@ -326,7 +326,7 @@ Group.</p>
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2009/sparql/wiki/Main_Page">SPARQL (1.1) WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2013/REC-rdf-sparql-XMLres-20130321/">SPARQL Query Results XML Format (Second Edition)</a>, ed. Sandro Hawke, W3C Recommendation.</p>
               <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#sparql-star-query-results-xml-format">Section 4.7.2 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 18 months</i></p>
             </dd>
           </dl>
 
@@ -343,17 +343,17 @@ Group.</p>
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2009/sparql/wiki/Main_Page">SPARQL (1.1) WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2013/REC-sparql11-service-description-20130321/">SPARQL 1.1  Service Description</a>, ed. Gregory Todd Williams, W3C Recommendation.</p>
               <p class="draft-status"><b>Reference:</b> <i>none</i></p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 24 months</i></p>
             </dd>
 
-            <dt id="sparql11-federated-query" class="spec">SPARQL <span class="issue">1.2</span>  Federated Query</dt>
+            <dt id="sparql11-federated-query" class="spec">SPARQL <span class="issue">1.2</span> Federated Query</dt>
             <dd>
               <p>This specification defines the syntax and semantics of SPARQL 1.1 Federated Query for executing queries distributed over different SPARQL endpoints.</p>
 
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2009/sparql/wiki/Main_Page">SPARQL (1.1) WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2013/REC-sparql11-federated-query-20130321/">SPARQL 1.1 Federated Query</a>, eds. Eric Prud'hommeaux, Carlos Buil-Aranda, W3C Recommendation.</p>
               <p class="draft-status"><b>Reference:</b> <i>none</i></p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 24 months</i></p>
             </dd>
 
             <dt id="sparql11-entailment-regimes" class="spec">SPARQL <span class="issue">1.2</span> Entailment Regimes</dt>
@@ -363,7 +363,7 @@ Group.</p>
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2009/sparql/wiki/Main_Page">SPARQL (1.1) WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2013/REC-sparql11-entailment-20130321/">SPARQL 1.1 Entailment Regimes</a>, eds. Birte Glimm, Chimezie Ogbuji, W3C Recommendation.</p>
               <p class="draft-status"><b>Reference:</b> <i>none</i></p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 24 months</i></p>
             </dd>
 
            <dt id="sparql-11-protocol" class="spec">SPARQL <span class="issue">1.2</span> Protocol</dt>
@@ -372,7 +372,7 @@ Group.</p>
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2009/sparql/wiki/Main_Page">SPARQL (1.1) WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2013/REC-sparql11-protocol-20130321/">SPARQL 1.1 Protocol</a>, eds.  Lee Feigenbaum, Gregory Todd Williams, Kendall Grant Clark (1st edition), Elias Torres (1str edition), W3C Recommendation.</p>
               <p class="draft-status"><b>Reference:</b> <i>none</i></p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 24 months</i></p>
             </dd>
 
            <dt id="sparql11-graph-store-http-protocol" class="spec">SPARQL <span class="issue">1.2</span> Graph Store HTTP Protocol</dt>
@@ -382,7 +382,7 @@ Group.</p>
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2009/sparql/wiki/Main_Page">SPARQL (1.1) WG</a></p>
               <p><b>Adopted Draft:</b> <a href="http://www.w3.org/TR/2013/REC-sparql11-http-rdf-update-20130321/">SPARQL 1.1  Graph Store HTTP Protocol</a>, ed. Chimezie Ogbuji, W3C Recommendation.</p>
               <p class="draft-status"><b>Reference:</b> <i>none</i></p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 24 months</i></p>
             </dd>
 
             <dt id="sparql11-results-csv-and-tsv" class="spec">SPARQL <span class="issue">1.2</span> Query Results CSV and TSV Format</dt>
@@ -392,7 +392,7 @@ Group.</p>
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2009/sparql/wiki/Main_Page">SPARQL (1.1) WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2013/REC-sparql11-results-csv-tsv-20130321/">SPARQL 1.1 Query Results CSV and TSV Formats</a>, ed. Andy Seaborne, W3C Recommendation.</p>
               <p class="draft-status"><b>Reference:</b> <i>none</i></p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + 24 months</i></p>
             </dd>
           </dl>
 

--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
               Team Contacts
             </th>
             <td>
-              <span class="todo"><a href="mailto:pierre-antoine@w3.org">Pierre-Antoine Champin</a></span> (0.15 <abbr title="Full-Time Equivalent">FTE</abbr>)
+              <span><a href="mailto:pierre-antoine@w3.org">Pierre-Antoine Champin</a></span> (0.15 <abbr title="Full-Time Equivalent">FTE</abbr>)
             </td>
           </tr>
           <tr>
@@ -197,7 +197,7 @@
 
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2011/rdf-wg/wiki/Main_Page">RDF WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2014/REC-rdf11-concepts-20140225/">RDF 1.1 Concepts and Abstract Syntax</a>, eds. Richard Cyganiak, David Wood, Markus Lanthaler, W3C Recommendation.</p>
-              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#concepts"><i class="todo">Section 2</i> of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
+              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#concepts">Section 2 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
               <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
             </dd>
 
@@ -207,7 +207,7 @@
 
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2011/rdf-wg/wiki/Main_Page">RDF WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2014/REC-n-quads-20140225/">RDF 1.1 N-Quads</a>, ed. Gavin Carothers, W3C Recommendation.</p>
-              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#n-quads-star"><i class="todo">Section 3.5</i> of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
+              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#n-quads-star">Section 3.5 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
               <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
             </dd>
 
@@ -217,7 +217,7 @@
 
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2011/rdf-wg/wiki/Main_Page">RDF WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2014/REC-n-triples-20140225/">RDF 1.1 N-Triples</a>, eds. Gavin Carothers, Andy Seaborne, W3C Recommendation.</p>
-              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#n-triples-star"><i class="todo">Section 3.4</i> of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
+              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#n-triples-star">Section 3.4 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
               <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
             </dd>
 
@@ -227,7 +227,7 @@
 
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2011/rdf-wg/wiki/Main_Page">RDF WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2014/REC-rdf11-mt-20140225/">RDF 1.1 Semantics</a>, eds. Patrick J. Hayes, Peter F. Patel-Schneider, W3C Recommendation.</p>
-              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#rdf-star-semantics"><i class="todo">Section 6</i> of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
+              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#rdf-star-semantics">Section 6 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
               <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
             </dd>
 
@@ -237,7 +237,7 @@
 
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2011/rdf-wg/wiki/Main_Page">RDF WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2014/REC-trig-20140225/">RDF 1.1 TriG</a>, eds. Gavin Carothers, Andy Seaborne, W3C Recommendation.</p>
-              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#trig-star"><i class="todo">Section 3.3</i> of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
+              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#trig-star">Section 3.3 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
               <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
             </dd>
 
@@ -247,7 +247,7 @@
 
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2011/rdf-wg/wiki/Main_Page">RDF WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2014/REC-turtle-20140225/">RDF 1.1 Turtle</a>, eds. Eric Prud'hommeaux, Gavin Carothers, W3C Recommendation.</p>
-              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#turtle-star"><i class="todo">Section 3.2</i> of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
+              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#turtle-star">Section 3.2 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
               <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
             </dd>
 
@@ -267,7 +267,7 @@
 
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2011/rdf-wg/wiki/Main_Page">RDF WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2014/REC-rdf-schema-20140225/">RDF Schema 1.1</a>, eds. Dan Brickley, R.V. Guha, W3C Recommendation.</p>
-              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#rdf-star-vocabulary"><i class="todo">Section 7</i> of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
+              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#rdf-star-vocabulary">Section 7 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
               <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
             </dd>
             </dl>
@@ -295,7 +295,7 @@ Group.</p>
 
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2009/sparql/wiki/Main_Page">SPARQL (1.1) WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2013/REC-sparql11-query-20130321/">SPARQL 1.1 Query Language</a>, eds. Steve Harris, Andy Seaborne, W3C Recommendation.</p>
-              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#sparql-star"><i class="todo">Section 4</i> of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
+              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#sparql-star">Section 4 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
               <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
             </dd>
 
@@ -305,7 +305,7 @@ Group.</p>
 
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2009/sparql/wiki/Main_Page">SPARQL (1.1) WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2013/REC-sparql11-update-20130321/">SPARQL 1.1 Update</a>, eds. Paula Gearon, Alexandre Passant, Axel Polleres, W3C Recommendation.</p>
-              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#sparql-star-update"><i class="todo">Section 5</i> of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
+              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#sparql-star-update">Section 5 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
               <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
             </dd>
 
@@ -315,7 +315,7 @@ Group.</p>
 
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2009/sparql/wiki/Main_Page">SPARQL (1.1) WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2013/REC-sparql11-results-json-20130321/">SPARQL 1.1 Query Results JSON Format</a>, ed. Andy Seaborne, W3C Recommendation.</p>
-              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#sparql-star-query-results-json-format"><i class="todo">Section 4.7.1</i> of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
+              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#sparql-star-query-results-json-format">Section 4.7.1 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
               <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
             </dd>
 
@@ -325,7 +325,7 @@ Group.</p>
 
               <p class="draft-status"><b>Draft state:</b> Adopted from the <a href="https://www.w3.org/2009/sparql/wiki/Main_Page">SPARQL (1.1) WG</a></p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2013/REC-rdf-sparql-XMLres-20130321/">SPARQL Query Results XML Format (Second Edition)</a>, ed. Sandro Hawke, W3C Recommendation.</p>
-              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#sparql-star-query-results-xml-format"><i class="todo">Section 4.7.2</i> of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
+              <p class="draft-status"><b>Reference:</b> <a href="https://www.w3.org/2021/12/rdf-star.html#sparql-star-query-results-xml-format">Section 4.7.2 of RDF-star and SPARQL-star</a>, eds. Olaf Hartig, Pierre-Antoine Champin, Gregg Kellogg, Andy Seaborne, W3C Community Group Final Report, 2021. </p>
               <p class="milestone"><b>Expected completion:</b> <i class="todo">WG-START + X months</i></p>
             </dd>
           </dl>
@@ -544,7 +544,7 @@ Group.</p>
           Decision Policy
         </h2>
         <p>
-          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus"> W3C Process Document (section 3.3</a>). Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
+          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus"> W3C Process Document (section 3.3</a>). Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
         <p>
            However, if a decision is necessary for timely progress and consensus is not achieved after careful consideration of the range of views presented, the Chairs may call for a group vote and record a decision along with any objections.
         </p>


### PR DESCRIPTION
arbitrary choices I made:
* planned 12 months for RDF specs that are quite ready
  (abstract and concrete syntaxes)
* planned 18 months for RDF specs that still need some work
  (semantics, vocabulary)
* planned 18 months for SPARQL specs that are quite ready
  (but they depend on RDF, and are usually longer)
* planned 24 months for other SPARQL specs

I didn't find any place to mention "we will recharter if we need more time",
and anyway, this goes more or less without saying...


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star-wg-charter/pull/33.html" title="Last updated on May 4, 2022, 4:36 PM UTC (8fb1870)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star-wg-charter/33/e734161...8fb1870.html" title="Last updated on May 4, 2022, 4:36 PM UTC (8fb1870)">Diff</a>