### PR TITLE
fix wrong link

### DIFF
--- a/index.html
+++ b/index.html
@@ -492,7 +492,7 @@ Group.</p>
 
             <dt><a href="https://www.iso.org/committee/45342.html">ISO/IEC JTC 1/SC 32</a> Data management and interchange</dt>
             <dd>Through the <a href="https://www.w3.org/2001/11/StdLiaison#ISO">existing liaison with W3C</a>, to coordinate with the efforts around graph query languages
-              (<a href="https://www.iso.org/standard/76120.html">GQL</a> and <a href="https://www.iso.org/standard/76120.html">SQL/PGQ</a>).</dd>
+              (<a href="https://www.iso.org/standard/76120.html">GQL</a> and <a href="https://www.iso.org/standard/79473.html">SQL/PGQ</a>).</dd>
           </dl>
         </section>
       </section>


### PR DESCRIPTION
wrong link in SQL/PGQ


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/domel/rdf-star-wg-charter/pull/51.html" title="Last updated on Jun 19, 2022, 10:17 AM UTC (bc7ab39)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star-wg-charter/51/26fb6d6...domel:bc7ab39.html" title="Last updated on Jun 19, 2022, 10:17 AM UTC (bc7ab39)">Diff</a>