### PR TITLE
renaming do not occur mid-charter

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
 
         <p>The group SHOULD ensure that any RDF 1.1 data remains valid in this new version. Furthermore, any RDF or RDFS entailment drawn under RDF 1.1 semantics SHOULD also remain valid in this new version.</p>
 
-        <p class="note">The name of this Working Group ("RDF-star") was chosen to emphasize the new feature that RDF 1.2 is providing compared to RDF 1.1. When the Working Group switches to maintenance mode, it might request to change its name to a more general designation (e.g. "RDF" or "RDF &amp; SPARQL") to be decided then.</p>
+        <p class="note">The name of this Working Group ("RDF-star") was chosen to emphasize the new feature that RDF 1.2 is providing compared to RDF 1.1. In a future rechartering, it might change its name to a more general designation (e.g. "RDF" or "RDF &amp; SPARQL"), to be decided then.</p>
 
         <section id="section-out-of-scope">
           <h3 id="out-of-scope">Out of Scope</h3>


### PR DESCRIPTION
I got feedback from other W3C staff members, that renaming a group mid-charter is very unusual.

So I rephrase the note about renaming to suggest that the name change would occur in a future rechartering instead.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star-wg-charter/pull/59.html" title="Last updated on Jun 13, 2024, 12:21 PM UTC (af351f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star-wg-charter/59/455940e...af351f7.html" title="Last updated on Jun 13, 2024, 12:21 PM UTC (af351f7)">Diff</a>